### PR TITLE
Distribute Pricing FAQ into other sections

### DIFF
--- a/src/faq.njk
+++ b/src/faq.njk
@@ -25,7 +25,6 @@ pageType: "faq"
     <a href="#coaching" class="faq-nav-link" onclick="scrollToSection(event, 'coaching')">Coaching Services</a>
     <a href="#mentorship" class="faq-nav-link" onclick="scrollToSection(event, 'mentorship')">Professional Mentorship</a>
     <a href="#medico-legal" class="faq-nav-link" onclick="scrollToSection(event, 'medico-legal')">Medico-Legal</a>
-    <a href="#pricing" class="faq-nav-link" onclick="scrollToSection(event, 'pricing')">Pricing</a>
     <a href="#other" class="faq-nav-link" onclick="scrollToSection(event, 'other')">Questions about EDS</a>
   </div>
 </div>
@@ -155,6 +154,16 @@ pageType: "faq"
 
     <div class="faq-item">
       <button class="faq-question" onclick="toggleFaq(this)">
+        <span>Does Hypermobility MD accept insurance?</span>
+        <svg class="faq-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
+      </button>
+      <div class="faq-answer">
+        <p>Hypermobility MD is an out-of-network practice and does not contract with or accept payments from any insurance company. We do not submit claims on your behalf, but a superbill can be provided upon request for possible reimbursement through your out-of-network benefits. Dr. Bluestein does not participate in Medicare or Medicaid.</p>
+      </div>
+    </div>
+
+    <div class="faq-item">
+      <button class="faq-question" onclick="toggleFaq(this)">
         <span>How do we create an environment where a diverse range of patients and clients feel comfortable seeking care?</span>
         <svg class="faq-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
       </button>
@@ -225,6 +234,37 @@ pageType: "faq"
         <p>The complete policies and procedures for our medical services can be found <a href="/assets/HMD_Policies_and_Procedures.pdf" target="_blank" rel="noopener">here</a>.</p>
       </div>
     </div>
+
+    <div class="faq-item">
+      <button class="faq-question" onclick="toggleFaq(this)">
+        <span>How much do new patient medical appointments cost?</span>
+        <svg class="faq-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
+      </button>
+      <div class="faq-answer">
+        <p>New patient appointments are offered as one of three packages, selected to match the complexity of your medical history. Each package includes one follow-up visit, which must be scheduled within 2 months of the initial appointment.</p>
+        <ul>
+          <li><strong>Gold</strong> &mdash; single, discrete medical issue. 90-minute initial visit, 25-minute follow-up. <strong>$1,800</strong></li>
+          <li><strong>Platinum</strong> &mdash; 2&ndash;3 straightforward medical issues. 150-minute initial visit, 50-minute follow-up. <strong>$2,500</strong></li>
+          <li><strong>Diamond</strong> &mdash; complex medical issue(s). 210-minute initial visit, 90-minute follow-up. <strong>$3,000</strong></li>
+        </ul>
+        <p>The first appointment must be in person in Wisconsin or Colorado. Full details are in our <a href="/assets/HMD_Pricing.pdf" target="_blank" rel="noopener">pricing and packages document</a>.</p>
+      </div>
+    </div>
+
+    <div class="faq-item">
+      <button class="faq-question" onclick="toggleFaq(this)">
+        <span>How much do follow-up visits cost for existing patients?</span>
+        <svg class="faq-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
+      </button>
+      <div class="faq-answer">
+        <ul>
+          <li><strong>25 minutes</strong> &mdash; for very limited issues &mdash; <strong>$350</strong></li>
+          <li><strong>50 minutes</strong> &mdash; standard follow-up &mdash; <strong>$600</strong></li>
+          <li><strong>105 minutes</strong> &mdash; recommended for multiple or complex topics &mdash; <strong>$900</strong></li>
+        </ul>
+        <p>Most follow-ups are scheduled every 1&ndash;3 months. To remain an active patient, you must be seen in person at least once every 12 months.</p>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -272,6 +312,16 @@ pageType: "faq"
         </ul>
       </div>
     </div>
+    <div class="faq-item">
+      <button class="faq-question" onclick="toggleFaq(this)">
+        <span>How much do EduCoaching sessions cost?</span>
+        <svg class="faq-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
+      </button>
+      <div class="faq-answer">
+        <p>EduCoaching is offered in four session levels (Bronze, Silver, Gold, and Platinum) through Bendy Bodies, LLC. Current rates and availability are listed in the <a href="https://bendybodies.janeapp.com/" target="_blank" rel="noopener">coaching portal</a>. Full details on what each session includes are in our <a href="/assets/BB_Policies_and_Procedures.pdf" target="_blank" rel="noopener">coaching policies and procedures</a>.</p>
+      </div>
+    </div>
+
     <div class="faq-item">
       <button class="faq-question" onclick="toggleFaq(this)">
         <span>Where can I find more details about the coaching services?</span>
@@ -350,6 +400,16 @@ pageType: "faq"
         <p>Absolutely. While a single session can be incredibly valuable, some professionals prefer ongoing mentorship. You&rsquo;re welcome to book sessions as needed, or select a package for longer-term support.</p>
       </div>
     </div>
+
+    <div class="faq-item">
+      <button class="faq-question" onclick="toggleFaq(this)">
+        <span>How much do professional mentorship sessions cost?</span>
+        <svg class="faq-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
+      </button>
+      <div class="faq-answer">
+        <p>Mentorship sessions are 20, 50, or 80 minutes. Current rates and availability are listed in the <a href="https://bendybodies.janeapp.com/" target="_blank" rel="noopener">coaching portal</a>.</p>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -413,64 +473,6 @@ pageType: "faq"
         <p>Please reach out through the <a href="/contact/">contact form</a> and select Medico-Legal Consulting. Include a brief description of the case and the type of services you are seeking (record review, written opinion, deposition, trial). A member of the team will follow up with rate information and availability.</p>
       </div>
     </div>
-  </div>
-</section>
-
-<!-- Pricing -->
-<section class="section" id="pricing">
-  <div class="container faq-container">
-    <h2 class="faq-section-title"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="faq-title-icon"><circle cx="12" cy="12" r="10"/><path d="M16 8h-6a2 2 0 1 0 0 4h4a2 2 0 1 1 0 4H8"/><path d="M12 18V6"/></svg>Pricing</h2>
-
-    <div class="faq-item">
-      <button class="faq-question" onclick="toggleFaq(this)">
-        <span>How much do new patient medical appointments cost?</span>
-        <svg class="faq-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
-      </button>
-      <div class="faq-answer">
-        <p>New patient appointments are offered as one of three packages, selected to match the complexity of your medical history. Each package includes one follow-up visit, which must be scheduled within 2 months of the initial appointment.</p>
-        <ul>
-          <li><strong>Gold</strong> &mdash; single, discrete medical issue. 90-minute initial visit, 25-minute follow-up. <strong>$1,800</strong></li>
-          <li><strong>Platinum</strong> &mdash; 2&ndash;3 straightforward medical issues. 150-minute initial visit, 50-minute follow-up. <strong>$2,500</strong></li>
-          <li><strong>Diamond</strong> &mdash; complex medical issue(s). 210-minute initial visit, 90-minute follow-up. <strong>$3,000</strong></li>
-        </ul>
-        <p>The first appointment must be in person in Wisconsin or Colorado. Full details are in our <a href="/assets/HMD_Pricing.pdf" target="_blank" rel="noopener">pricing and packages document</a>.</p>
-      </div>
-    </div>
-
-    <div class="faq-item">
-      <button class="faq-question" onclick="toggleFaq(this)">
-        <span>How much do follow-up visits cost for existing patients?</span>
-        <svg class="faq-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
-      </button>
-      <div class="faq-answer">
-        <ul>
-          <li><strong>25 minutes</strong> &mdash; for very limited issues &mdash; <strong>$350</strong></li>
-          <li><strong>50 minutes</strong> &mdash; standard follow-up &mdash; <strong>$600</strong></li>
-          <li><strong>105 minutes</strong> &mdash; recommended for multiple or complex topics &mdash; <strong>$900</strong></li>
-        </ul>
-        <p>Most follow-ups are scheduled every 1&ndash;3 months. To remain an active patient, you must be seen in person at least once every 12 months.</p>
-      </div>
-    </div>
-
-    <div class="faq-item">
-      <button class="faq-question" onclick="toggleFaq(this)">
-        <span>How much do EduCoaching sessions cost?</span>
-        <svg class="faq-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
-      </button>
-      <div class="faq-answer">
-        <p>EduCoaching is offered in four session levels (Bronze, Silver, Gold, and Platinum) through Bendy Bodies, LLC. Current rates and availability are listed in the <a href="https://bendybodies.janeapp.com/" target="_blank" rel="noopener">coaching portal</a>. Full details on what each session includes are in our <a href="/assets/BB_Policies_and_Procedures.pdf" target="_blank" rel="noopener">coaching policies and procedures</a>.</p>
-      </div>
-    </div>
-
-    <div class="faq-item">
-      <button class="faq-question" onclick="toggleFaq(this)">
-        <span>How much do professional mentorship sessions cost?</span>
-        <svg class="faq-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
-      </button>
-      <div class="faq-answer">
-        <p>Mentorship sessions are 20, 50, or 80 minutes. Current rates and availability are listed in the <a href="https://bendybodies.janeapp.com/" target="_blank" rel="noopener">coaching portal</a>.</p>
-      </div>
-    </div>
 
     <div class="faq-item">
       <button class="faq-question" onclick="toggleFaq(this)">
@@ -481,31 +483,11 @@ pageType: "faq"
         <p>Medico-legal rates depend on the type of engagement (record review, written opinion, deposition, or trial testimony) and the scope of the case. Please <a href="/contact/">contact us</a> with a brief description of the matter for a custom quote.</p>
       </div>
     </div>
-
-    <div class="faq-item">
-      <button class="faq-question" onclick="toggleFaq(this)">
-        <span>Does Hypermobility MD accept insurance?</span>
-        <svg class="faq-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
-      </button>
-      <div class="faq-answer">
-        <p>Hypermobility MD is an out-of-network practice and does not contract with or accept payments from any insurance company. We do not submit claims on your behalf, but a superbill can be provided upon request for possible reimbursement through your out-of-network benefits. Dr. Bluestein does not participate in Medicare or Medicaid.</p>
-      </div>
-    </div>
-
-    <div class="faq-item">
-      <button class="faq-question" onclick="toggleFaq(this)">
-        <span>What payment methods are accepted?</span>
-        <svg class="faq-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
-      </button>
-      <div class="faq-answer">
-        <p>Clients and patients are directly responsible for payment. We accept credit cards and Venmo (@Linda-Bluestein). Full details are available in the respective portals.</p>
-      </div>
-    </div>
   </div>
 </section>
 
 <!-- Questions about EDS -->
-<section class="section section-alt" id="other">
+<section class="section" id="other">
   <div class="container faq-container">
     <h2 class="faq-section-title"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="faq-title-icon"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg>Questions about EDS</h2>
     <p style="color: var(--text-muted); margin-bottom: 24px;">Explore in-depth articles on common questions about EDS, hypermobility, and related conditions.</p>
@@ -556,7 +538,7 @@ pageType: "faq"
 </section>
 
 <!-- CTA -->
-<section class="section" style="text-align: center;">
+<section class="section section-alt" style="text-align: center;">
   <div class="container">
     <h2>Still Have Questions?</h2>
     <p style="color: var(--text-muted); max-width: 500px; margin: 12px auto 24px;">Don&rsquo;t hesitate to reach out. We&rsquo;re happy to help you understand your options.</p>
@@ -593,7 +575,7 @@ function scrollToSection(e, id) {
 
 // Highlight active section on scroll
 window.addEventListener('scroll', () => {
-  const sections = ['who', 'general', 'medical', 'coaching', 'mentorship', 'medico-legal', 'pricing', 'other'];
+  const sections = ['who', 'general', 'medical', 'coaching', 'mentorship', 'medico-legal', 'other'];
   let current = sections[0];
   for (const id of sections) {
     const el = document.getElementById(id);


### PR DESCRIPTION
## Summary

- Removes the standalone **Pricing** FAQ section and redistributes its questions into the sections they belong to:
  - Medical appointment & follow-up costs → **Medical Services**
  - EduCoaching costs → **Coaching Services**
  - Mentorship costs → **Professional Mentorship**
  - Medico-legal costs → **Medico-Legal**
  - Insurance question → **General (Medical & Coaching Services)**
- Drops the duplicate "What payment methods are accepted?" (already covered by "What are the payment options?" in General)
- Removes the Pricing nav link and fixes section background alternation

## Test plan

- [ ] Verify all 6 redistributed questions appear in their new sections
- [ ] Confirm the Pricing nav link is gone and scroll tracking works without it
- [ ] Check section background colors alternate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)